### PR TITLE
Readme - Setup Steps Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,45 +2,47 @@
 
 Offical site for Codeuino landing page. Please visit [http://www.codeuino.org/](http://www.codeuino.org/)
 
-### Table of contents
+## Table of contents
 
- - Requirements
- - Installation
- - File Structure
- - How to contribute
- - Credits
- 
- ## Requirements
- Following applications are required to run the application locally.
- 
- - Git
- - Npm
- - Node
+- Requirements
+- Installation
+- File Structure
+- How to contribute
+- Credits
+
+## Requirements
+
+Following applications are required to run the application locally.
+
+- Git
+- Npm
+- Node
 
 ## Installation
+
 To run the application on your local system follow these steps
 
- 1. <code>git clone https://github.com/codeuino/website-www.codeuino.org.git</code>
+ 1. `git clone https://github.com/codeuino/website-www.codeuino.org.git`
  2. Move to the project directory.
- 3. <code>git checkout development</code>
- 4. <code>npm install</code>
- 5. Open <code>localhost:3000</code> to view the website on your local browser.
+ 3. `git checkout development`
+ 4. `npm install`
+ 5. Open `localhost:3000` to view the website on your local browser.
 
 ## File Structure
 
 This section describes about the file structure of the project.
-All the source code is located in <code>src</code> directory.
-There are two main directories in the src folder, <code>components</code> and <code>pages</code>.
+All the source code is located in `src` directory.
+There are two main directories in the src folder, `components` and `pages`.
 The pages directory contains all the source code of routes in separate folders.
 The components directory contains all reusable component file in separate folders.
 
 ## Dockerizing the application
 
-### To use the application in docker for both production and development use, follow:
+### To use the application in docker for both production and development use, follow
 
-- Build and tag docker image <code> docker image build -f  Dockerfile-dev  -t {name-of-docker-file-of-your-choice}  . </code>
+- Build and tag docker image ` docker image build -f  Dockerfile-dev  -t {name-of-docker-file-of-your-choice}  . `
 
-- Running docker image <code> lakshyadocker run -it -v ${PWD}:/app -v /app/node_modules -p {Port-you-want-your-app-on}:3000 --rm {docker-image} </code>
+- Running docker image ` lakshyadocker run -it -v ${PWD}:/app -v /app/node_modules -p {Port-you-want-your-app-on}:3000 --rm {docker-image} `
 
 ## How to contribute
 
@@ -50,9 +52,9 @@ The components directory contains all reusable component file in separate folder
 
 You should usually [open an issue](https://github.com/codeuino/website-www.codeuino.org/issues/new) in the following situations:
 
-* Report an error you can’t solve yourself
-* Discuss a high-level topic or idea (for example, community, vision or policies)
-* Propose a new feature or other project idea
+- Report an error you can’t solve yourself
+- Discuss a high-level topic or idea (for example, community, vision or policies)
+- Propose a new feature or other project idea
 
 **Tips for communicating on issues:**
 
@@ -66,8 +68,8 @@ If you opened an issue, but figured out the answer later on your own, comment on
 
 You should usually open a pull request in the following situations:
 
-* Submit trivial fixes (for example, a typo, a broken link or an obvious error)
-* Start work on a contribution that was already asked for, or that you’ve already discussed, in an issue
+- Submit trivial fixes (for example, a typo, a broken link or an obvious error)
+- Start work on a contribution that was already asked for, or that you’ve already discussed, in an issue
 A pull request doesn’t have to represent finished work. It’s usually better to open a pull request early on, so others can watch or give feedback on your progress. Just mark it as a “WIP” (Work in Progress) in the subject line. You can always add more commits later.
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ To run the application on your local system follow these steps
  2. Move to the project directory.
  3. `git checkout development`
  4. `npm install`
- 5. Open `localhost:3000` to view the website on your local browser.
+ 5. `npm run build`
+ 6. `npm start`
+ 7. Open `localhost:5000` to view the website on your local browser.
 
 ## File Structure
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "start": "serve -s build -l 3000",
     "build": "CI=false && set \"CI=false\" && react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start-dev": "react-scripts start"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   },
   "scripts": {
     "heroku-postbuild": "npm run build",
-    "start": "serve -s build",
-    "build": "set \"CI=false\" && react-scripts build",
+    "start": "serve -s build -l 3000",
+    "build": "CI=false && set \"CI=false\" && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^9.4.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
+    "enzyme": "^3.11.0",
     "highlight.js": "^9.17.1",
     "history": "^4.10.1",
     "html-to-markdown": "^1.0.0",
@@ -35,7 +36,8 @@
     "react-slideshow-image": "^1.3.3",
     "react-twitter-embed": "^3.0.3",
     "semantic-ui-react": "^0.88.2",
-    "serve": "^11.3.0"
+    "serve": "^11.3.0",
+    "typescript": "^3.9.6"
   },
   "resolutions": {
     "react-dev-utils": "10.1.0"


### PR DESCRIPTION
Contributors new to this project might be unable to do the setup following the current docs, as was I and got this error.

![Screenshot from 2020-07-06 16-55-53](https://user-images.githubusercontent.com/39027928/86596464-dfa0d000-bfb7-11ea-976c-a0e17e768b7f.png)

Hence the docs are updated.
Here is a list of changes made - 

- Added a script for local development
- Updated setup steps in `README.md`
- set the port of `serve` to `3000` from the default `5000`
- made markdown syntax in `README.md` compliant with markdownLint
- Added some missing dependencies which were casing some warnings in fresh environments
- added multiple ways to set `CI=false` environment variable so that deployments don't fail because of warning being treated as errors.